### PR TITLE
Harden inotifywait loop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ if [[ $? != 0 ]] || test -t 0; then exit $?; fi
 log "HAProxy started with $HAPROXY_CONFIG config, pid $(cat $HAPROXY_PID_FILE)." && log
 
 # Check if config or certificates were changed
-while inotifywait -q -r --exclude '\.git/' -e modify -e create -e delete $HAPROXY_CONFIG /etc/letsencrypt; do
+while inotifywait -q -r --exclude '\.git/' -e modify,create,delete,move,move_self $HAPROXY_CONFIG /etc/letsencrypt; do
   if [ -f $HAPROXY_PID_FILE ]; then
     log "Restarting HAProxy due to config changes..." #&& print_config
     if $HAPROXY_CHECK_CONFIG_CMD; then


### PR DESCRIPTION
Add move and move_self events to inotifywait event list. 
This enables editing with vim and manual moving of certificates.